### PR TITLE
#6 FatVcの解消のためのRepository構造体の追加とその他修正

### DIFF
--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		8A6109542E4F1B70006051D1 /* Repository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6109532E4F1B70006051D1 /* Repository.swift */; };
+		8A6109562E4F1B8B006051D1 /* GitHubAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6109552E4F1B8B006051D1 /* GitHubAPIClient.swift */; };
 		BF0A658D244F2A3B00280FA6 /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0A658C244F2A3B00280FA6 /* DetailViewController.swift */; };
 		BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945DE244DC5E80012785A /* AppDelegate.swift */; };
 		BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945E0244DC5E80012785A /* SceneDelegate.swift */; };
@@ -36,6 +38,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		8A6109532E4F1B70006051D1 /* Repository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Repository.swift; sourceTree = "<group>"; };
+		8A6109552E4F1B8B006051D1 /* GitHubAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubAPIClient.swift; sourceTree = "<group>"; };
 		BF0A658C244F2A3B00280FA6 /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
 		BFD945DB244DC5E80012785A /* iOSEngineerCodeCheck.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSEngineerCodeCheck.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BFD945DE244DC5E80012785A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -105,6 +109,8 @@
 				BFD945E0244DC5E80012785A /* SceneDelegate.swift */,
 				BFD945E2244DC5E80012785A /* RootViewController.swift */,
 				BF0A658C244F2A3B00280FA6 /* DetailViewController.swift */,
+				8A6109532E4F1B70006051D1 /* Repository.swift */,
+				8A6109552E4F1B8B006051D1 /* GitHubAPIClient.swift */,
 				BFD945E4244DC5E80012785A /* Main.storyboard */,
 				BFD945E7244DC5EB0012785A /* Assets.xcassets */,
 				BFD945E9244DC5EB0012785A /* LaunchScreen.storyboard */,
@@ -265,6 +271,8 @@
 			files = (
 				BFD945E3244DC5E80012785A /* RootViewController.swift in Sources */,
 				BF0A658D244F2A3B00280FA6 /* DetailViewController.swift in Sources */,
+				8A6109562E4F1B8B006051D1 /* GitHubAPIClient.swift in Sources */,
+				8A6109542E4F1B70006051D1 /* Repository.swift in Sources */,
 				BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */,
 				BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */,
 			);

--- a/iOSEngineerCodeCheck.xcodeproj/xcshareddata/xcschemes/iOSEngineerCodeCheck.xcscheme
+++ b/iOSEngineerCodeCheck.xcodeproj/xcshareddata/xcschemes/iOSEngineerCodeCheck.xcscheme
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1640"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BFD945DA244DC5E80012785A"
+               BuildableName = "iOSEngineerCodeCheck.app"
+               BlueprintName = "iOSEngineerCodeCheck"
+               ReferencedContainer = "container:iOSEngineerCodeCheck.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BFD945F0244DC5EB0012785A"
+               BuildableName = "iOSEngineerCodeCheckTests.xctest"
+               BlueprintName = "iOSEngineerCodeCheckTests"
+               ReferencedContainer = "container:iOSEngineerCodeCheck.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BFD945FB244DC5EB0012785A"
+               BuildableName = "iOSEngineerCodeCheckUITests.xctest"
+               BlueprintName = "iOSEngineerCodeCheckUITests"
+               ReferencedContainer = "container:iOSEngineerCodeCheck.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BFD945DA244DC5E80012785A"
+            BuildableName = "iOSEngineerCodeCheck.app"
+            BlueprintName = "iOSEngineerCodeCheck"
+            ReferencedContainer = "container:iOSEngineerCodeCheck.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+         <AdditionalOption
+            key = "MallocStackLogging"
+            value = ""
+            isEnabled = "YES">
+         </AdditionalOption>
+         <AdditionalOption
+            key = "PrefersMallocStackLoggingLite"
+            value = ""
+            isEnabled = "YES">
+         </AdditionalOption>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BFD945DA244DC5E80012785A"
+            BuildableName = "iOSEngineerCodeCheck.app"
+            BlueprintName = "iOSEngineerCodeCheck"
+            ReferencedContainer = "container:iOSEngineerCodeCheck.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/iOSEngineerCodeCheck/Base.lproj/Main.storyboard
+++ b/iOSEngineerCodeCheck/Base.lproj/Main.storyboard
@@ -76,8 +76,8 @@
                                     <constraint firstAttribute="width" secondItem="Iim-eb-8Ad" secondAttribute="height" multiplier="1:1" id="CoT-OC-9DA"/>
                                 </constraints>
                             </imageView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4q1-pG-WSB">
-                                <rect key="frame" x="181" y="554" width="52" height="33.5"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Title" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4q1-pG-WSB">
+                                <rect key="frame" x="20" y="554" width="374" height="34"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                 <color key="textColor" systemColor="darkTextColor"/>
                                 <nil key="highlightedColor"/>
@@ -150,7 +150,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="rj0-Ld-RTn" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="230" y="137"/>
+            <point key="canvasLocation" x="228.98550724637684" y="136.60714285714286"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="hWi-qa-NBR">

--- a/iOSEngineerCodeCheck/DetailView.swift
+++ b/iOSEngineerCodeCheck/DetailView.swift
@@ -1,0 +1,9 @@
+//
+//  DetailView.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by Kota Yamaguchi on 2025/08/16.
+//  Copyright © 2025 YUMEMI Inc. All rights reserved.
+//
+
+import Foundation

--- a/iOSEngineerCodeCheck/GitHubAPIClient.swift
+++ b/iOSEngineerCodeCheck/GitHubAPIClient.swift
@@ -1,0 +1,53 @@
+//
+//  GitHubAPIClient.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by Kota Yamaguchi on 2025/08/15.
+//  Copyright © 2025 YUMEMI Inc. All rights reserved.
+//
+
+import Foundation
+
+// API通信時に発生しうるエラーを定義
+enum APIError: Error {
+    case invalidURL
+    case networkError(Error)
+    case decodingError(Error)
+    case noData
+}
+
+struct GitHubAPIClient {
+    
+    func searchRepositories(query: String, completion: @escaping (Result<[Repository], APIError>) -> Void) {
+        guard let url = URL(string: "https://api.github.com/search/repositories?q=\(query)") else {
+            completion(.failure(.invalidURL))
+            return
+        }
+        
+        let task = URLSession.shared.dataTask(with: url) { data, response, error in
+            if let error = error {
+                completion(.failure(.networkError(error)))
+                return
+            }
+            
+            guard let data = data else {
+                completion(.failure(.noData))
+                return
+            }
+            
+            do {
+                let decoder = JSONDecoder()
+                let searchResponse = try decoder.decode(SearchResponse.self, from: data)
+                // UI更新はメインスレッドで行うため、ここで切り替える
+                DispatchQueue.main.async {
+                    completion(.success(searchResponse.items))
+                }
+            } catch let decodingError {
+                DispatchQueue.main.async {
+                    completion(.failure(.decodingError(decodingError)))
+                }
+            }
+        }
+        task.resume()
+    }
+}

--- a/iOSEngineerCodeCheck/Repository.swift
+++ b/iOSEngineerCodeCheck/Repository.swift
@@ -1,0 +1,45 @@
+//
+//  Repository.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by Kota Yamaguchi on 2025/08/15.
+//  Copyright © 2025 YUMEMI Inc. All rights reserved.
+//
+
+import Foundation
+
+// APIレスポンス全体に合わせた構造体
+struct SearchResponse: Codable {
+    let items: [Repository]
+}
+
+// リポジトリのデータを保持する構造体
+struct Repository: Codable {
+    let fullName: String
+    let language: String?
+    let stargazersCount: Int
+    let watchersCount: Int
+    let forksCount: Int
+    let openIssuesCount: Int
+    let owner: Owner
+
+    // JSONのsnake_caseキーをSwiftのcamelCaseにマッピング
+    enum CodingKeys: String, CodingKey {
+        case fullName = "full_name"
+        case language
+        case stargazersCount = "stargazers_count"
+        case watchersCount = "watchers_count"
+        case forksCount = "forks_count"
+        case openIssuesCount = "open_issues_count"
+        case owner
+    }
+}
+
+// オーナー情報（アバター画像URL）を保持する構造体
+struct Owner: Codable {
+    let avatarURL: String
+
+    enum CodingKeys: String, CodingKey {
+        case avatarURL = "avatar_url"
+    }
+}

--- a/iOSEngineerCodeCheck/RootView.swift
+++ b/iOSEngineerCodeCheck/RootView.swift
@@ -1,0 +1,29 @@
+//
+//  RootView.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by Kota Yamaguchi on 2025/08/16.
+//  Copyright © 2025 YUMEMI Inc. All rights reserved.
+//
+
+import SwiftUI
+
+struct RootView: View {
+    @State private var searchText = ""
+    var body :some View {
+        NavigationStack{
+            
+            List{
+                
+            }
+            .searchable(text: $searchText, prompt: Text("GitHubのリポジトリを検索できるよー"))
+            .navigationTitle("GitHubリポジトリ検索")
+        }
+        
+    }
+}
+    
+
+#Preview {
+    RootView()
+}


### PR DESCRIPTION
RootViewControllerをDetailViewController内で参照しているのはリポジトリ情報だけだったので、class自体を参照して循環参照を引き起こすのではなく、リポジトリ情報単体のみを渡すことで循環参照を回避している。